### PR TITLE
Leave a copy of response body on res object.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -8,4 +8,5 @@ module.exports = ->
     err.reformat()
     res.set err.output.headers
     res.status err.output.statusCode
-    res.json err.output.payload
+    res.body = err.output.payload
+    res.json res.body


### PR DESCRIPTION
For downstream middlewares to access.

There doesn't appear to be any other way for a middleware that runs after a response has been sent to access the sent response body (e.g useful for logging).